### PR TITLE
fix: avoid cyclic require

### DIFF
--- a/packages/utilities/selectors/plugins.js
+++ b/packages/utilities/selectors/plugins.js
@@ -9,7 +9,8 @@ const {
   remove,
   assocPath,
 } = require('ramda')
-const {error} = '@rescripts/utilities'
+
+const {error} = '../errors'
 
 const pluginsLens = lensProp('plugins')
 


### PR DESCRIPTION
This PR fixes a cyclic require in utilities.

`const {error} = '@rescripts/utilities'` creates a cyclic require usage and nullifies `error` method, making all exception handling in the same file throw without proper error message.