### PR TITLE
Fix typo for installing tslint rescript

### DIFF
--- a/packages/rescripts/use-tslint-config/README.md
+++ b/packages/rescripts/use-tslint-config/README.md
@@ -7,7 +7,7 @@ Use your own TSLint configuration.
 ## Installation
 
 ```sh
-npm i -D @rescripts/rescript-use-tsint-config
+npm i -D @rescripts/rescript-use-tslint-config
 ```
 
 ## Usage


### PR DESCRIPTION
simple typo fix I noticed when copy and pasting the install command.