### PR TITLE
Load custom config --config also from absolute path

### DIFF
--- a/packages/cli/loader.js
+++ b/packages/cli/loader.js
@@ -1,5 +1,5 @@
 const {
-  findIndex,
+  find,
   either,
   equals,
   type,
@@ -18,22 +18,29 @@ const {
   load,
 } = require('@rescripts/utilities')
 
+const loadCustomConfig = path => 
+  loadRawFromRoot(path) ||
+  loadFromRoot(path) ||
+  load(path) ||
+  error(
+    `Unable to load config file by provided path '${path}'`,
+  )
+
+const loadStandardConfig = () => 
+  loadFromPackageField('rescripts') ||
+  loadRawFromRoot('.rescriptsrc') ||
+  loadFromRoot('.rescriptsrc') ||
+  error(
+    'You\'re likely seeing this bug because you haven\'t defined a root rescript or your root rescript contains a syntactical error. If you\'re certain of otherwise, please file an issue.',
+  )
+
 const rootRescript = (() => {
-  const configKeyI = findIndex(
+  const customConfigPath = find(
     either(equals('--config'), equals('-c')),
     process.argv,
   )
 
-  const loaded =
-    configKeyI >= 0
-      ? loadRawFromRoot(process.argv[configKeyI + 1]) ||
-        loadFromRoot(process.argv[configKeyI + 1])
-      : loadFromPackageField('rescripts') ||
-        loadRawFromRoot('.rescriptsrc') ||
-        loadFromRoot('.rescriptsrc') ||
-        error(
-          'You\'re likely seeing this bug because you haven\'t defined a root rescript or your root rescript contains a syntactical error. If you\'re certain of otherwise, please file an issue.',
-        )
+  const loaded = customConfigPath ? loadCustomConfig(customConfigPath) : loadStandardConfig()
 
   switch (type(loaded)) {
     case 'Function':


### PR DESCRIPTION
- tries to load custom config also from absolute path
- if `--config` or `-c` is provided, show an error if it failed to resolve config based on provided path 

see https://github.com/harrysolovay/rescripts/issues/21#issuecomment-456214301