### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -770,8 +770,6 @@ module.exports = [
 const equal = require('deep-equal')
 let lastConfig = null
 
-logConfig.isMiddleware = true
-
 module.exports = [
   ['use-babel-config', '.babelrc'],
   ['use-tslint-config', 'tslint.json'],


### PR DESCRIPTION
simplified form of middleware example does not use `logConfig.isMiddleware` anymore