### PR TITLE
Load eslintConfig from the correct field in package.json

### DIFF
--- a/packages/rescripts/use-eslint-config/index.js
+++ b/packages/rescripts/use-eslint-config/index.js
@@ -47,7 +47,7 @@ module.exports = source => config =>
             }
             case 'package':
             case 'package.json': {
-              const eslintConfig = loadFromPackageField('babel')
+              const eslintConfig = loadFromPackageField('eslintConfig')
               return useConfigFile(eslintConfig, subConfig)
             }
             default: {


### PR DESCRIPTION
`use-eslint-config` was using the `babel` field when `'package'` or `'package.json'` option was passed. This corrects it to the `eslintConfig` field.