### PR TITLE
Add more use configs to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,10 +795,12 @@ We prefer to keep and mutate a `lastConfig` reference incase other middleware is
 - [use-babel-config](https://github.com/rescripts/rescripts/blob/master/packages/rescripts/use-babel-config) – specify a Babel configuration
 - [use-eslint-config](https://github.com/rescripts/rescripts/blob/master/packages/rescripts/use-eslint-config) – specify an ESLint configuration
 - [use-tslint-config](https://github.com/rescripts/rescripts/blob/master/packages/rescripts/use-tslint-config) – specify a TSLint configuration
+- [use-babel-jest-config](https://github.com/jsxtools/rescript-use-babel-jest-config) - specify a Babel Jest configuration
+- [use-postcss-config](https://github.com/jsxtools/rescript-use-postcss-config) - specify a PostCSS configuration
 - [use-rewire](https://github.com/rescripts/rescripts/blob/master/packages/rescripts/use-rewire) – use a rewire designed for react-app-rewired
 - [use-stylelint-config](https://github.com/rescripts/rescripts/blob/master/packages/rescripts/use-stylelint-config) – specify a StyleLint config (works for CSS, SCSS & CSS-in-JS)
 - [rescript-worker-loader](https://github.com/linonetwo/rescript-worker-loader) - Enable [web worker loader](https://github.com/webpack-contrib/worker-loader) in webpack
-- [rescript-disable-eslint](https://github.com/linonetwo/rescript-disable-eslint) - Disable preflight eslint check, for those who only wants to check it in the code editor and CI. 
+- [rescript-disable-eslint](https://github.com/linonetwo/rescript-disable-eslint) - Disable preflight eslint check, for those who only wants to check it in the code editor and CI.
 - **MORE COMING SOON!**
 
 ## Miscellaneous


### PR DESCRIPTION
I have just published 2 rescript configs that might be helpful to others.

- [use-babel-jest-config](https://github.com/jsxtools/rescript-use-babel-jest-config) - specify a Babel Jest configuration
- [use-postcss-config](https://github.com/jsxtools/rescript-use-postcss-config) - specify a PostCSS configuration