### PR TITLE
Update @rescripts/cli to support react-scripts v2 & v3

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,7 +11,7 @@
   },
   "repository": "https://github.com/rescripts/rescripts/tree/master/packages/cli",
   "peerDependencies": {
-    "react-scripts": "^2.1.2"
+    "react-scripts": "2 - 3"
   },
   "dependencies": {
     "@rescripts/utilities": "^0.0.5",


### PR DESCRIPTION
This change updates the react-scripts peer dependency to include all v2 and v3 releases, resolving an issue where @rescripts/cli errantly reports incompatibility with react scripts v3.

Resolves #49