### PR TITLE
Use `require` when importing from errors.js

### DIFF
--- a/packages/utilities/selectors/plugins.js
+++ b/packages/utilities/selectors/plugins.js
@@ -10,7 +10,7 @@ const {
   assocPath,
 } = require('ramda')
 
-const {error} = '../errors'
+const {error} = require('../errors')
 
 const pluginsLens = lensProp('plugins')
 


### PR DESCRIPTION
Fixes #75