### PR TITLE
Allow version 3 of react-scripts similar to existing dep in @rescripts/cli

### DIFF
--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -9,7 +9,7 @@
   },
   "repository": "https://github.com/rescripts/rescripts/tree/master/packages/utilities",
   "peerDependencies": {
-    "react-scripts": "^2.1.2"
+    "react-scripts": "2 - 3"
   },
   "dependencies": {
     "ramda": "^0.26.0"


### PR DESCRIPTION
I didn't test this yet but just copied from @rescripts/cli, hopefully fixed to avoid this warning

warning "@rescripts/cli > @rescripts/utilities@0.0.6" has incorrect peer dependency "react-scripts@^2.1.2".


